### PR TITLE
ranksテーブルにposted_atのカラムを追加

### DIFF
--- a/app/models/discord_bot.rb
+++ b/app/models/discord_bot.rb
@@ -19,12 +19,12 @@ class DiscordBot
       end
     end
 
-    @bot.reaction_remove do |event|
-      if event.server.id.to_s == ENV['DISCORD_SERVER_ID']
-        point = -1
-        reaction_create(event, point)
-      end
-    end
+    # @bot.reaction_remove do |event|
+    #   if event.server.id.to_s == ENV['DISCORD_SERVER_ID']
+    #     point = -1
+    #     reaction_create(event, point)
+    #   end
+    # end
   end
 
   def member_watching

--- a/app/models/ranks_updater.rb
+++ b/app/models/ranks_updater.rb
@@ -63,6 +63,7 @@ class RanksUpdater
       rank.author_name = message_information_parsed['author']['username']
       rank.author_avatar = message_information_parsed['author']['avatar']
       rank.author_discriminator = message_information_parsed['author']['discriminator']
+      rank.posted_at = message_information_parsed['timestamp']
     end
   end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
         thread_name: スレッド
         content: 投稿内容
         author_name: 投稿者
+        posted_at: 投稿日時
   date:
     formats:
       default: "%Y年%m月%d日"

--- a/db/migrate/20220531120420_add_posted_at_to_ranks.rb
+++ b/db/migrate/20220531120420_add_posted_at_to_ranks.rb
@@ -1,0 +1,5 @@
+class AddPostedAtToRanks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ranks, :posted_at, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_012240) do
+ActiveRecord::Schema.define(version: 2022_05_31_120420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2022_05_30_012240) do
     t.string "author_discriminator", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "posted_at", null: false
     t.index ["order"], name: "index_ranks_on_order"
   end
 


### PR DESCRIPTION
Issue:
- #66 

バズった発言をdiscordとサイトで発表する際にその発言の投稿日時を表示するため