### PR TITLE
絵文字の収集と集計方法を見直した

### DIFF
--- a/app/models/discord_bot.rb
+++ b/app/models/discord_bot.rb
@@ -19,12 +19,12 @@ class DiscordBot
       end
     end
 
-    # @bot.reaction_remove do |event|
-    #   if event.server.id.to_s == ENV['DISCORD_SERVER_ID']
-    #     point = -1
-    #     reaction_create(event, point)
-    #   end
-    # end
+    @bot.reaction_remove do |event|
+      if event.server.id.to_s == ENV['DISCORD_SERVER_ID']
+        point = -1
+        reaction_create(event, point)
+      end
+    end
   end
 
   def member_watching

--- a/app/models/ranks_updater.rb
+++ b/app/models/ranks_updater.rb
@@ -12,7 +12,7 @@ class RanksUpdater
   private
 
   def create_ranks
-    yesterday_reactions = Reaction.where(reacted_at: Time.zone.yesterday.all_day)
+    yesterday_reactions = Reaction.where(reacted_at: Time.zone.today.all_day)
     # yesterday_reactions = Reaction.all
     # sorted_yesterday_massages = yesterday_reactions.limit(30).order('sum_point desc').group(:message_id).sum(:point)
     sorted_yesterday_massages = yesterday_reactions.order('sum_point desc').group(:message_id).sum(:point)
@@ -85,6 +85,8 @@ class RanksUpdater
   end
 
   def create_emojis(emoji_hash, yesterday_reactions, message, rank_record)
+    return if emoji_hash.nil?
+
     emoji_hash.each do |hash_emoji|
       next unless yesterday_reactions.where(message_id: message[0], emoji_name: hash_emoji['emoji']['name']).sum(:point).positive?
 

--- a/app/models/ranks_updater.rb
+++ b/app/models/ranks_updater.rb
@@ -12,7 +12,7 @@ class RanksUpdater
   private
 
   def create_ranks
-    yesterday_reactions = Reaction.where(reacted_at: Time.zone.today.all_day)
+    yesterday_reactions = Reaction.where(reacted_at: Time.zone.yesterday.all_day)
     # yesterday_reactions = Reaction.all
     # sorted_yesterday_massages = yesterday_reactions.limit(30).order('sum_point desc').group(:message_id).sum(:point)
     sorted_yesterday_massages = yesterday_reactions.order('sum_point desc').group(:message_id).sum(:point)

--- a/app/views/ranks/index.html.slim
+++ b/app/views/ranks/index.html.slim
@@ -8,8 +8,8 @@
         h4
           | 昨日は絵文字スタンプのリアクションがありませんでした。
       - else
-        h1 #{@ranks.first.created_at.ago(1.day).strftime('%Y/%m/%d')}のBuzzcordランキング一覧
-        .card-deck.mt-4
+        h1.mt-3 #{@ranks.first.created_at.ago(1.day).strftime('%Y/%m/%d')}のBuzzcordランキング一覧
+        .card-deck.mt-3
           - @ranks.each do |rank|
             .card.content-card.bg-mythemea.mb-3.bg-body.rounded.text-center
               .card-header.fs-3.fw-bold.bg-mythemeb


### PR DESCRIPTION
- botによる絵文字リアクションの収集を、削除時にも行う方法に戻す
- 集計方法に、絵文字が0の場合を含めた(絵文字の追加→削除が日をまたいだ場合や設定を変更していた場合などにあり得る)