### PR TITLE
bootstrapをgemとyarnの両方でインストールしていたためgemを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# gem 'bootstrap'
 gem 'discordrb', github: 'shardlab/discordrb', branch: 'threads'
 gem 'dotenv-rails'
 gem 'html2slim'

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'bootstrap'
+# gem 'bootstrap'
 gem 'discordrb', github: 'shardlab/discordrb', branch: 'threads'
 gem 'dotenv-rails'
 gem 'html2slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,15 +77,9 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.7.0)
-      execjs (~> 2)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
-    bootstrap (5.1.3)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.3, < 3)
-      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     bullet (7.0.1)
       activesupport (>= 3.0.0)
@@ -115,7 +109,6 @@ GEM
       railties (>= 3.2)
     erubi (1.10.0)
     event_emitter (0.2.6)
-    execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -206,7 +199,6 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.5)
-    popper_js (2.9.3)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -388,7 +380,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
-  bootstrap
   bullet
   byebug
   capybara

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link_directory ../stylesheets

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,1 @@
 //= link_tree ../images
-//= link_directory ../stylesheets

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,0 @@
-@import "bootstrap";

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the homes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the homes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/ranks.scss
+++ b/app/assets/stylesheets/ranks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the ranks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/ranks.scss
+++ b/app/assets/stylesheets/ranks.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the ranks controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,15 +1,7 @@
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-
 import Rails from "@rails/ujs";
 import Turbolinks from "turbolinks";
-// import * as ActiveStorage from "@rails/activestorage";
-// import "channels";
 import "bootstrap";
 import "../stylesheets/application.scss";
 
 Rails.start();
 Turbolinks.start();
-// ActiveStorage.start();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,7 +1,15 @@
+// This file is automatically compiled by Webpack, along with any other files
+// present in this directory. You're encouraged to place your actual application logic in
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
+
 import Rails from "@rails/ujs";
 import Turbolinks from "turbolinks";
+// import * as ActiveStorage from "@rails/activestorage";
+// import "channels";
 import "bootstrap";
 import "../stylesheets/application.scss";
 
 Rails.start();
 Turbolinks.start();
+// ActiveStorage.start();

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,6 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = favicon_link_tag '/favicon.ico'

--- a/app/views/layouts/homes.html.slim
+++ b/app/views/layouts/homes.html.slim
@@ -6,7 +6,6 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     script src="https://kit.fontawesome.com/ee5a02ffb8.js" crossorigin="anonymous"


### PR DESCRIPTION
町田さんよりcssが二重で読み込まれていると教えていただき、修正を行いました。

参照:
11009ee06841baa0ea4aad5ab24699b34daeca0d
2ed0b0ba098f8c197aaa4557bce7b97327f38a1b

Bootstrap5のインストールをgemとyarnで2回行ってしまっていました。
gemをインストール時に行った設定を戻して、cssが二重で読み込まれていないことを確認しました。

修正後も、rubocopとRSpecのテストを通過し、サイト表示に目視で崩れがないことを確認しました。

[修正前]
![スクリーンショット 2022-06-17 19 31 59](https://user-images.githubusercontent.com/82434093/174288482-d304c930-be87-4471-b480-96b88df518cc.png)

[ 修正後]
![スクリーンショット 2022-06-17 19 30 05](https://user-images.githubusercontent.com/82434093/174288568-aefbc257-b63a-4ad8-97e3-e3aec5547fa4.png)
