### PR TITLE
カスタム絵文字のnameに英大文字小文字数字が入る可能性に対応

### DIFF
--- a/app/models/ranks_updater.rb
+++ b/app/models/ranks_updater.rb
@@ -56,8 +56,8 @@ class RanksUpdater
   end
 
   def convert_custom_emoji(content)
-    regexp = /(<:[a-z]+:[0-9]+>)/
-    regexp2 = /<(:[a-z]+:)([0-9]+)>/
+    regexp = /(<:[0-9a-zA-Z]+:[0-9]+>)/
+    regexp2 = /<(:[0-9a-zA-Z]+:)([0-9]+)>/
     content.split(regexp).map do |word|
       matched = word.match(regexp2)
       matched ? [matched[1], matched[2]] : word


### PR DESCRIPTION
カスタム絵文字jの名称(name)に英大文字小文字と数字が入る可能性を考慮していなかったため対応しました。