### PR TITLE
トップページのロゴ画像の大きさを修正した

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -49,5 +49,5 @@ img.colsm {
   }
 
 img.logo {
-  width: 30%;
+  width: 20%;
   }


### PR DESCRIPTION
設定値が大きすぎたため30%→20%に修正した