### PR TITLE
ランキングページのcssと文言を見直し

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,14 +13,14 @@ html
     = favicon_link_tag '/android-chrome-256x256.png', rel: 'icon', sizes: '256x256', type: 'image/png'
     link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css" rel="stylesheet" /
   body
-    .app-title.navbar.navbar-expand-md.navbar-light.bg-mythemee.px-3
-      .container-fluid
+    .app-title.navbar.navbar-expand-md.navbar-light.bg-mythemee
+      .container
         .navbar-brand
           = image_tag('buzzcordr.svg', alt: 'buzzcord', class: 'logo-header')
         .col-md-0.text-end
           .text-white
             = current_user.name
-            = image_tag current_user.avatar, class: 'rounded-circle mx-3 avatar'
+            = image_tag current_user.avatar, class: 'rounded-circle ms-3 avatar'
     .container
       - if flash.notice
         .flash-message.notice.alert.alert-danger = notice

--- a/app/views/ranks/index.html.slim
+++ b/app/views/ranks/index.html.slim
@@ -1,14 +1,14 @@
 .ranks
-  h2.bg-mythemec.my-4.py-3.rounded-pill.text-center
+  h3.mt-4.text-center
     | サーバー名: #{@guild_name}
   - if @ranks.empty?
-    h1.mb-4.text-center
-      | #{l(Time.zone.yesterday, format: :short)}のBuzzcordランキング一覧
+    h2.text-center.bg-mythemec.my-4.py-3.rounded-pill.
+      | #{l(Time.zone.yesterday, format: :short)}のBuzzcordランキング
     h4
       | 昨日は絵文字スタンプのリアクションがありませんでした。
   - else
-    h1.my-3.text-center
-      | #{l(@ranks.first.created_at.ago(1.day), format: :short)}のBuzzcordランキング一覧
+    h2.text-center.bg-mythemec.my-4.py-3.rounded
+      | #{l(@ranks.first.created_at.ago(1.day), format: :short)}のBuzzcordランキング
     .card-deck
       - @ranks.each do |rank|
         .card.content-card.bg-mythemea.mb-3.bg-body.text-center

--- a/spec/system/ranks_spec.rb
+++ b/spec/system/ranks_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Ranks', type: :system do
     it '表示件数の確認' do
       sign_in_as(user)
 
-      expect(page).to have_content 'のBuzzcordランキング一覧'
+      expect(page).to have_content 'のBuzzcordランキング'
       expect(page).to have_content('Rank:', count: 5)
     end
 

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Welcome', type: :system do
     sign_in_as(user)
 
     expect(page).to have_content 'ログインしました。'
-    expect(page).to have_content 'のBuzzcordランキング一覧'
+    expect(page).to have_content 'のBuzzcordランキング'
   end
 
   it 'ログインしているユーザがログアウトできる' do
@@ -34,6 +34,6 @@ RSpec.describe 'Welcome', type: :system do
     sign_in_as(user)
     visit root_path
 
-    expect(page).to have_content 'のBuzzcordランキング一覧'
+    expect(page).to have_content 'のBuzzcordランキング'
   end
 end


### PR DESCRIPTION
ランキングページ内
- css
    - ヘッダーの表示幅を変更
    - cssを見直し
- 文言を変更
- 文言の変更に合わせてテストを変更