### PR TITLE
ランキング内の絵文字一覧の数が0以下の場合は表示しない

### DIFF
--- a/app/views/ranks/_rank_emojis.html.slim
+++ b/app/views/ranks/_rank_emojis.html.slim
@@ -2,15 +2,16 @@
   .rank-emojis__items
     - if emojis.present?
       - emojis.each do |emoji|
-        - if emoji.emoji_id.present?
-          .rank-emojis__item.rounded
-            span
-              = image_tag("https://cdn.discordapp.com/emojis/#{emoji.emoji_id}.webp?size=16&quality=lossless", alt: emoji.emoji_name)
-            span
-              = emoji.count
-        - else
-          .rank-emojis__item.rounded
-            span
-              = emoji.emoji_name
-            span
-              = emoji.count
+        - if emoji.count.positive?
+          - if emoji.emoji_id.present?
+            .rank-emojis__item.rounded
+              span
+                = image_tag("https://cdn.discordapp.com/emojis/#{emoji.emoji_id}.webp?size=16&quality=lossless", alt: emoji.emoji_name)
+              span
+                = emoji.count
+          - else
+            .rank-emojis__item.rounded
+              span
+                = emoji.emoji_name
+              span
+                = emoji.count

--- a/spec/system/ranks_spec.rb
+++ b/spec/system/ranks_spec.rb
@@ -4,55 +4,73 @@ require 'rails_helper'
 
 RSpec.describe 'Ranks', type: :system do
   describe 'ランキング一覧の表示' do
-    before do
-      rank = []
-      1.upto(5).each do |n|
-        rank[n] = create(:rank, order: n, content: "テスト投稿です！_#{n}")
+    context 'ランクインした投稿の表示テスト' do
+      before do
+        rank = []
+        1.upto(5).each do |n|
+          rank[n] = create(:rank, order: n, content: "テスト投稿です！_#{n}")
+        end
+      end
+
+      let(:user) { create(:user) }
+
+      it '表示件数の確認' do
+        sign_in_as(user)
+
+        expect(page).to have_content 'のランキング'
+        expect(page).to have_selector('.rank-main__title', text: 'Hana', count: 5)
+      end
+
+      it 'ランキングと表示内容の一致の確認' do
+        sign_in_as(user)
+        element = all('.rank').find { |component| component.has_selector?('.is-rank-1') }
+        within element do
+          expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_1'
+        end
+        element = all('.rank').find { |component| component.has_selector?('.is-rank-2') }
+        within element do
+          expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_2'
+        end
+        element = all('.rank').find { |component| component.has_selector?('.is-rank-3') }
+        within element do
+          expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_3'
+        end
+        element = all('.rank').find { |component| component.has_selector?('.is-rank-4') }
+        within element do
+          expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_4'
+        end
+        element = all('.rank').find { |component| component.has_selector?('.is-rank-5') }
+        within element do
+          expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_5'
+        end
+      end
+
+      let(:ranks) { page.all('.rank') }
+      it 'レコード順を保持している' do
+        sign_in_as(user)
+
+        expect(ranks[0].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_1'
+        expect(ranks[1].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_2'
+        expect(ranks[2].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_3'
+        expect(ranks[3].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_4'
+        expect(ranks[4].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_5'
       end
     end
-
-    let(:user) { create(:user) }
-
-    it '表示件数の確認' do
-      sign_in_as(user)
-
-      expect(page).to have_content 'のランキング'
-      expect(page).to have_selector('.rank-main__title', text: 'Hana', count: 5)
-    end
-
-    it 'ランキングと表示内容の一致の確認' do
-      sign_in_as(user)
-      element = all('.rank').find { |component| component.has_selector?('.is-rank-1') }
-      within element do
-        expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_1'
+    context '絵文字一覧の表示テスト' do
+      let(:user) { create(:user) }
+      it '絵文字数が0の場合は表示されない' do
+        rank = create(:rank)
+        create(:emoji, rank_id: rank.id, emoji_name: '😊', count: 0)
+        sign_in_as(user)
+        expect(page).to_not have_content '😊'
       end
-      element = all('.rank').find { |component| component.has_selector?('.is-rank-2') }
-      within element do
-        expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_2'
-      end
-      element = all('.rank').find { |component| component.has_selector?('.is-rank-3') }
-      within element do
-        expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_3'
-      end
-      element = all('.rank').find { |component| component.has_selector?('.is-rank-4') }
-      within element do
-        expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_4'
-      end
-      element = all('.rank').find { |component| component.has_selector?('.is-rank-5') }
-      within element do
-        expect(page).to have_selector '.rank-main__text.card-text', text: 'テスト投稿です！_5'
-      end
-    end
 
-    let(:ranks) { page.all('.rank') }
-    it 'レコード順を保持している' do
-      sign_in_as(user)
-
-      expect(ranks[0].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_1'
-      expect(ranks[1].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_2'
-      expect(ranks[2].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_3'
-      expect(ranks[3].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_4'
-      expect(ranks[4].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_5'
+      it '絵文字数がマイナスの場合は表示されない' do
+        rank = create(:rank)
+        create(:emoji, rank_id: rank.id, emoji_name: '🙏', count: -2)
+        sign_in_as(user)
+        expect(page).to_not have_content '🙏'
+      end
     end
   end
 end


### PR DESCRIPTION
Issue:
- #145 

ランキング内の絵文字一覧で数が0以下の場合は間違えて押された場合がほとんどなので表示しないよう変更した。
テストも作成した。