### PR TITLE
投稿文内のカスタム絵文字名にアンダースコアが含まれている場合も変換できるように修正した

### DIFF
--- a/app/models/custom_emoji_converter.rb
+++ b/app/models/custom_emoji_converter.rb
@@ -2,8 +2,8 @@
 
 class CustomEmojiConverter
   def self.call(content)
-    regexp = /(<:[0-9a-zA-Z]+:[0-9]+>)/
-    regexp2 = /<(:[0-9a-zA-Z]+:)([0-9]+)>/
+    regexp = /(<:[0-9a-zA-Z_]+:[0-9]+>)/
+    regexp2 = /<(:[0-9a-zA-Z_]+:)([0-9]+)>/
     contents_all = +''
     content.split(regexp).map do |word|
       matched = word.match(regexp2)

--- a/spec/models/custom_emoji_converter_spec.rb
+++ b/spec/models/custom_emoji_converter_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe CustomEmojiConverter, type: :model do
         expect(contents_all).to eq "こんにちは！🎉 今日も暑かった！<img alt=':9666:' aria-label=':9666:' class='emoji' data-id='9883' data-type='emoji' draggable='false' src='https://cdn.discordapp.com/emojis/9883.webp?size=32&amp;quality=lossless'> 😍"
         # rubocop:enable Layout/LineLength
       end
+
+      it 'カスタム絵文字のemoji_nameにアンダースコアが含まれている場合もURLに変換されて文字列に格納される' do
+        content = 'こんにちは！🎉 今日も寒かった！<:abc_123_ddd:9888> 😍'
+        contents_all = CustomEmojiConverter.call(content)
+        # rubocop:disable Layout/LineLength
+        expect(contents_all).to eq "こんにちは！🎉 今日も寒かった！<img alt=':abc_123_ddd:' aria-label=':abc_123_ddd:' class='emoji' data-id='9888' data-type='emoji' draggable='false' src='https://cdn.discordapp.com/emojis/9888.webp?size=32&amp;quality=lossless'> 😍"
+        # rubocop:enable Layout/LineLength
+      end
     end
 
     context 'カスタム絵文字が含まれない投稿文' do


### PR DESCRIPTION
Issue:
- #146 

投稿文内のカスタム絵文字をサイトに表示する際、正規表現を使ってカスタム絵文字を抜き出してURLに変換している。
カスタム絵文字のemoji_nameにアンダースコアが含まれる可能性があることを考慮していなかったため対応した。

[カスタム絵文字 – Discord](https://support.discord.com/hc/ja/articles/360036479811-%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0%E7%B5%B5%E6%96%87%E5%AD%97#:~:text=%E7%B5%B5%E6%96%87%E5%AD%97%E5%90%8D%E3%81%AF%E6%9C%80%E4%BD%8E%E3%81%A7%E3%82%82,%E3%82%A2%E3%83%B3%E3%83%80%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AE%E3%81%BF%E5%85%A5%E5%8A%9B%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82)

テストも作成した。