### PR TITLE
スマホ表示の際のリンクボタンを1つに変更した

### DIFF
--- a/app/javascript/stylesheets/_rank-links.scss
+++ b/app/javascript/stylesheets/_rank-links.scss
@@ -8,12 +8,31 @@
   gap: 1rem;
 }
 
-.rank-links__item {
+.rank-links__item_discord {
   @include media-breakpoint-up(md) {
     min-width: 12rem;
   }
   @include media-breakpoint-down(md) {
-    flex: 1;
+    display: none;
+  }
+  .button-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .25rem;
+  }
+  span {
+    font-size: .75rem;
+  }
+}
+
+.rank-links__item_laptop {
+  @include media-breakpoint-up(md) {
+    min-width: 12rem;
+  }
+  @include media-breakpoint-down(md) {
+    width: 12rem;
+    margin: 0 auto;
   }
   .button-link {
     display: flex;

--- a/app/views/ranks/_rank.html.slim
+++ b/app/views/ranks/_rank.html.slim
@@ -43,13 +43,9 @@
           = render 'rank_emojis', emojis: rank.emojis
     .rank-links
       .rank-links__items
-        .rank-links__item
+        .rank-links__item_discord
           = link_to "discord://discord.com/channels/#{ENV['DISCORD_SERVER_ID']}/#{rank.thread_id || rank.channel_id}/#{rank.message_id}", class: 'btn button-link'
             i.bi.bi-discord
-            span
-              | アプリで開く
-        .rank-links__item
+        .rank-links__item_laptop
           = link_to "https://discord.com/channels/#{ENV['DISCORD_SERVER_ID']}/#{rank.thread_id || rank.channel_id}/#{rank.message_id}", class: 'btn button-link'
             i.bi.bi-laptop
-            span
-              | ブラウザで開く


### PR DESCRIPTION
Issue:
- #147 

- スマホサイズでの表示の際は「アプリから開く」のボタンが効かないため、「ブラウザから開く」ボタンのみ表示に変更した。
- スマホでは「ブラウザから開く」ボタンをクリック後アプリがインストールされていればアプリで表示されるため、「ブラウザから開く」の文言を消してアイコンのみとした。