### PR TITLE
サイトの表示順が崩れるバグを修正しました

### DIFF
--- a/app/controllers/ranks_controller.rb
+++ b/app/controllers/ranks_controller.rb
@@ -2,6 +2,6 @@
 
 class RanksController < ApplicationController
   def index
-    @ranks = Rank.includes(%i[emojis attachments])
+    @ranks = Rank.includes(%i[emojis attachments]).order('ranks.order asc')
   end
 end

--- a/spec/system/ranks_spec.rb
+++ b/spec/system/ranks_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'Ranks', type: :system do
   describe 'ランキング一覧の表示' do
     context 'ランクインした投稿の表示テスト' do
       before do
-        rank = []
+        @rank = []
         1.upto(5).each do |n|
-          rank[n] = create(:rank, order: n, content: "テスト投稿です！_#{n}")
+          @rank[n] = create(:rank, order: n, total_emojis_count: (20 - n), content: "テスト投稿です！_#{n}")
         end
       end
 
@@ -49,6 +49,19 @@ RSpec.describe 'Ranks', type: :system do
       it 'レコード順を保持している' do
         sign_in_as(user)
 
+        expect(ranks[0].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_1'
+        expect(ranks[1].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_2'
+        expect(ranks[2].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_3'
+        expect(ranks[3].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_4'
+        expect(ranks[4].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_5'
+      end
+
+      it '画像の添付を含むレコードがあってもレコード順を保持している' do
+        create(:attachment, rank_id: @rank[4].id)
+        create(:attachment, rank_id: @rank[4].id, attachment_id: 234_567, attachment_filename: '6666.png')
+
+        sign_in_as(user)
+        page.save_screenshot
         expect(ranks[0].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_1'
         expect(ranks[1].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_2'
         expect(ranks[2].find('.rank-main__text.card-text').text).to eq 'テスト投稿です！_3'


### PR DESCRIPTION
Issue:
- #151 

バグ発生要因:
- コントローラーのindexでorderの指定をしていなかった
- レコード作成時にソートしているのでそのまま表示されると思っていた

参考サイト:
- [SELECT](https://www.postgresql.jp/document/13/html/sql-select.html)
- [PostgreSQLでORDER BY区を指定しない場合の並び \- komagataのブログ](https://docs.komagata.org/5169)
- [PostgreSQLの並び順について \- Qiita](https://qiita.com/yshz/items/4c3175c43ce4426d67ec)

> ORDER BY句が指定された場合、返される行は指定した順番でソートされます。 ORDER BYが指定されない場合は、システムが計算過程で見つけた順番で行が返されます

- [【Rails入門】パフォーマンスが悪いならincludes/orderを検討しよう \| 侍エンジニアブログ](https://www.sejuku.net/blog/26168)

対応:
- コントローラーのindex内で、includesの後にorderを指定した
- 表示順は実装依存とのことだが、今回は添付画像を含むレコードが先頭に来ていたので、添付画像を含んだテストを追加した。