### PR TITLE
一昨日以前のデータを削除する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,9 @@ jobs:
 
       - name: yarn install
         run: yarn install --check-files
-        run: bundle exec bin/webpack
+
+      - name: webpack install
+        run: NODE_OPTIONS=--openssl-legacy-provider bin/webpack
 
       - name: Setup test DB
         run: bundle exec rails db:setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: yarn install
         run: yarn install --check-files
+        run: bundle exec bin/webpack
 
       - name: Setup test DB
         run: bundle exec rails db:setup

--- a/app/models/all_ranking_data_creator.rb
+++ b/app/models/all_ranking_data_creator.rb
@@ -11,5 +11,8 @@ class AllRankingDataCreator
       EmojisCreator.call(message, rank_record)
       AttachmentsCreator.call(message, rank_record)
     end
+
+    # 一昨日以前のリアクションデータの削除
+    Reaction.where('reacted_at < ?', Time.zone.yesterday).delete_all
   end
 end

--- a/spec/models/all_ranking_date_creator_spec.rb
+++ b/spec/models/all_ranking_date_creator_spec.rb
@@ -15,5 +15,16 @@ RSpec.describe RanksCreator, type: :model do
           .and change { Attachment.count }.from(1).to(0)
       end
     end
+    context '#一昨日以前のリアクションデータの削除' do
+      before do
+        create_list(:reaction, 5)
+        create_list(:reaction, 4, :reacted_before_yesterday)
+        create_list(:reaction, 3, :reacted_today)
+      end
+      it '昨日と今日のデータのみが残る' do
+        expect { Reaction.where('reacted_at < ?', Time.zone.yesterday).delete_all }
+          .to change { Reaction.count }.from(12).to(8)
+      end
+    end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,9 +1825,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001332:
-  version "1.0.30001341"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
-  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+  version "1.0.30001473"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz"
+  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
- Issue: #154 
- ランキングがうまく作成できなかった時のために、前日分のReactionデータは残す。
- 削除は一昨日以前のReactionデータ
- 初回は2022/7〜の約9ヶ月分のデータを大量削除するため、`delete_all`を使用した。
