### PR TITLE
Issue163: Attachments内attachment_filenameのデータ型をtextに変更した

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 bot: rails discord_bot:start
+release: bin/rails db:migrate

--- a/db/migrate/20240514223525_change_data_type_attachments_filename_to_text.rb
+++ b/db/migrate/20240514223525_change_data_type_attachments_filename_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeDataTypeAttachmentsFilenameToText < ActiveRecord::Migration[6.1]
+  def up
+    change_column :attachments, :attachment_filename, :text
+  end
+
+  def down
+    change_column :attachments, :attachment_filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_08_160902) do
+ActiveRecord::Schema.define(version: 2024_05_14_223525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2022_06_08_160902) do
   create_table "attachments", force: :cascade do |t|
     t.bigint "rank_id", null: false
     t.bigint "attachment_id"
-    t.string "attachment_filename"
+    t.text "attachment_filename"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["rank_id"], name: "index_attachments_on_rank_id"


### PR DESCRIPTION
## Issue
- #163

## 対応:
- データ型を変更するmigrationファイルを作成し、`rails db:migrate`を実施した。
- Heroku でのビルド時にmigrateを忘れないようにするため、procfile にmigrateの実施を記述した。
