### PR TITLE
ranks:createバッチのRate Limit対策とDiscord API呼び出し最適化

### DIFF
--- a/app/models/channel_array_maker.rb
+++ b/app/models/channel_array_maker.rb
@@ -3,12 +3,21 @@
 class ChannelArrayMaker
   def self.call(message)
     channel = message[0][0]
-    parsed = JSON.parse(DiscordApiClient.new.fetch_channel_info(channel))
+    parsed = fetch_channel(channel)
     if parsed.key?('thread_metadata')
       [channel, parsed['name'], parsed['parent_id'],
-       JSON.parse(DiscordApiClient.new.fetch_channel_info(parsed['parent_id']))['name']]
+       fetch_channel(parsed['parent_id'])['name']]
     else
       [nil, nil, channel, parsed['name']]
     end
   end
+
+  def self.fetch_channel(channel_id, attempt: 0)
+    JSON.parse(DiscordApiClient.new.fetch_channel_info(channel_id))
+  rescue JSON::ParserError
+    raise if attempt >= 3
+    sleep(2**attempt)
+    fetch_channel(channel_id, attempt: attempt + 1)
+  end
+  private_class_method :fetch_channel
 end

--- a/app/models/channel_array_maker.rb
+++ b/app/models/channel_array_maker.rb
@@ -16,6 +16,7 @@ class ChannelArrayMaker
     JSON.parse(DiscordApiClient.new.fetch_channel_info(channel_id))
   rescue JSON::ParserError
     raise if attempt >= 3
+
     sleep(2**attempt)
     fetch_channel(channel_id, attempt: attempt + 1)
   end

--- a/app/models/discord_bot.rb
+++ b/app/models/discord_bot.rb
@@ -58,8 +58,8 @@ class DiscordBot
 
   def reaction_create(event, point)
     Reaction.create! do |reaction|
-      reaction.channel_id = event.message.channel.id
-      reaction.message_id = event.message.id
+      reaction.channel_id = event.channel.id
+      reaction.message_id = event.message_id
       reaction.user_id = event.user.id
       reaction.emoji_name = event.emoji.name
       reaction.emoji_id = event.emoji.id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_14_223525) do
-
+ActiveRecord::Schema[7.2].define(version: 2024_05_14_223525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,8 +18,8 @@ ActiveRecord::Schema.define(version: 2024_05_14_223525) do
     t.bigint "rank_id", null: false
     t.bigint "attachment_id"
     t.text "attachment_filename"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["rank_id"], name: "index_attachments_on_rank_id"
   end
 
@@ -29,8 +28,8 @@ ActiveRecord::Schema.define(version: 2024_05_14_223525) do
     t.string "emoji_name", null: false
     t.bigint "emoji_id"
     t.integer "count", default: 0, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["rank_id"], name: "index_emojis_on_rank_id"
   end
 
@@ -46,9 +45,9 @@ ActiveRecord::Schema.define(version: 2024_05_14_223525) do
     t.string "author_name", null: false
     t.string "author_avatar"
     t.string "author_discriminator", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "posted_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "posted_at", precision: nil, null: false
     t.integer "total_emojis_count", null: false
     t.string "content_post"
     t.index ["order"], name: "index_ranks_on_order"
@@ -60,9 +59,9 @@ ActiveRecord::Schema.define(version: 2024_05_14_223525) do
     t.bigint "user_id", null: false
     t.string "emoji_name", null: false
     t.bigint "emoji_id"
-    t.datetime "reacted_at", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "reacted_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "point"
     t.index ["reacted_at"], name: "index_reactions_on_reacted_at"
   end
@@ -73,8 +72,8 @@ ActiveRecord::Schema.define(version: 2024_05_14_223525) do
     t.string "name", null: false
     t.string "avatar"
     t.string "discriminator", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 

--- a/spec/models/channel_array_maker_spec.rb
+++ b/spec/models/channel_array_maker_spec.rb
@@ -30,5 +30,31 @@ RSpec.describe ChannelArrayMaker, type: :model do
         expect(channel_array).to eq [nil, nil, 1_234_567, 'テストチャンネル']
       end
     end
+
+    context 'Rate Limitが発生したとき' do
+      before do
+        @message = [[1_234_567, 11_111], 20]
+        allow(ChannelArrayMaker).to receive(:sleep)
+      end
+
+      it 'JSON::ParserErrorが一度発生してもリトライして成功する' do
+        call_count = 0
+        allow_any_instance_of(DiscordApiClient).to receive(:fetch_channel_info) do
+          call_count += 1
+          raise JSON::ParserError if call_count == 1
+
+          { 'name': 'テストチャンネル' }.to_json
+        end
+
+        channel_array = ChannelArrayMaker.call(@message)
+        expect(channel_array).to eq [nil, nil, 1_234_567, 'テストチャンネル']
+      end
+
+      it '3回リトライしても失敗し続ける場合はJSON::ParserErrorを発生させる' do
+        allow_any_instance_of(DiscordApiClient).to receive(:fetch_channel_info).and_raise(JSON::ParserError)
+
+        expect { ChannelArrayMaker.call(@message) }.to raise_error(JSON::ParserError)
+      end
+    end
   end
 end

--- a/spec/models/discord_bot_spec.rb
+++ b/spec/models/discord_bot_spec.rb
@@ -16,43 +16,6 @@ RSpec.describe DiscordBot, type: :model do
     end
   end
 
-  describe '#reaction_create' do
-    let(:discord_bot) { DiscordBot.new }
-    let(:channel) { double('channel', id: 1_234_567) }
-    let(:user) { double('user', id: 7_654_321) }
-    let(:emoji) { double('emoji', name: 'test_emoji', id: nil) }
-    let(:event) do
-      double('event',
-             channel: channel,
-             message_id: 11_111,
-             user: user,
-             emoji: emoji)
-    end
-
-    before do
-      allow(Discordrb::Bot).to receive(:new).and_return(double('discordrb_bot'))
-    end
-
-    it 'Reactionレコードが作成される' do
-      expect { discord_bot.send(:reaction_create, event, 1) }.to change(Reaction, :count).by(1)
-    end
-
-    it 'event.channel.idとevent.message_idから属性を取得しevent.messageを呼ばない' do
-      expect(event).not_to receive(:message)
-      discord_bot.send(:reaction_create, event, 1)
-      reaction = Reaction.last
-      expect(reaction.channel_id).to eq 1_234_567
-      expect(reaction.message_id).to eq 11_111
-      expect(reaction.user_id).to eq 7_654_321
-      expect(reaction.point).to eq 1
-    end
-
-    it 'リアクション削除はpointが-1で保存される' do
-      discord_bot.send(:reaction_create, event, -1)
-      expect(Reaction.last.point).to eq(-1)
-    end
-  end
-
   describe '#member_watch' do
     context 'botがDiscordメンバーの退会と登録情報変更を検知したとき' do
       it '退会に合わせてUserレコード削除' do

--- a/spec/models/discord_bot_spec.rb
+++ b/spec/models/discord_bot_spec.rb
@@ -16,6 +16,43 @@ RSpec.describe DiscordBot, type: :model do
     end
   end
 
+  describe '#reaction_create' do
+    let(:discord_bot) { DiscordBot.new }
+    let(:channel) { double('channel', id: 1_234_567) }
+    let(:user) { double('user', id: 7_654_321) }
+    let(:emoji) { double('emoji', name: 'test_emoji', id: nil) }
+    let(:event) do
+      double('event',
+             channel: channel,
+             message_id: 11_111,
+             user: user,
+             emoji: emoji)
+    end
+
+    before do
+      allow(Discordrb::Bot).to receive(:new).and_return(double('discordrb_bot'))
+    end
+
+    it 'Reactionレコードが作成される' do
+      expect { discord_bot.send(:reaction_create, event, 1) }.to change(Reaction, :count).by(1)
+    end
+
+    it 'event.channel.idとevent.message_idから属性を取得しevent.messageを呼ばない' do
+      expect(event).not_to receive(:message)
+      discord_bot.send(:reaction_create, event, 1)
+      reaction = Reaction.last
+      expect(reaction.channel_id).to eq 1_234_567
+      expect(reaction.message_id).to eq 11_111
+      expect(reaction.user_id).to eq 7_654_321
+      expect(reaction.point).to eq 1
+    end
+
+    it 'リアクション削除はpointが-1で保存される' do
+      discord_bot.send(:reaction_create, event, -1)
+      expect(Reaction.last.point).to eq(-1)
+    end
+  end
+
   describe '#member_watch' do
     context 'botがDiscordメンバーの退会と登録情報変更を検知したとき' do
       it '退会に合わせてUserレコード削除' do


### PR DESCRIPTION
## Issue
- #166 

## 概要

毎日実行される `ranks:create` バッチが Discord API の Rate Limit（429）でクラッシュし、ランキングが作成されない問題を修正する。

### 背景

Heroku ログにて以下のエラーを確認：

```
JSON::ParserError: unexpected character: '<!doctype' at line 1 column 1
Caused by:
RestClient::TooManyRequests: 429 Too Many Requests
  channel_array_maker.rb:6 `fetch_channel_info`
```

**直接原因**: `channel_array_maker.rb` が Discord REST API を呼んだ際、Cloudflare レベルの 429 が返る。Cloudflare の 429 レスポンスボディは HTML のため、discordrb の Rate Limit ハンドラが `JSON.parse` に失敗してそのままクラッシュしていた（本来はリトライすべき）。

**根本原因**: `discord_bot.rb` の `reaction_create` が `event.message` を呼んでおり、リアクションが付くたびに Discord REST API（`load_message`）を叩いていた。`channel_id` と `message_id` はイベントデータから直接取得可能なため、この API 呼び出しは不要だった。リアクションが多い日はこの無駄なリクエストで Rate Limit の消費が大きくなり、`ranks:create` 実行時に即座に Cloudflare 429 に引っかかっていた。

---

## 変更内容

### 1. `db/schema.rb` — Rails 7.2 書式への更新

Rails 7.2 環境でマイグレーションを実行した際に自動生成されたフォーマット変更。スキーマの内容に変更はなく、PR #165 の Rails 7.2 アップグレード時に含まれるべきだった残件。

- `ActiveRecord::Schema.define` → `ActiveRecord::Schema[7.2].define`
- `precision: 6` の削除（Rails 7.2 ではマイクロ秒精度がデフォルトのため省略）
- `posted_at`、`reacted_at` に `precision: nil` を明示

### 2. `app/models/discord_bot.rb` — 不要な Discord API 呼び出しを除去

`reaction_create` メソッド内で `event.message` を経由して `channel_id` と `message_id` を取得していたが、これは毎回 `load_message` REST API を発生させる無駄な呼び出しだった。discordrb のイベントデータから直接取得できる `event.channel.id` と `event.message_id` に変更する。

```ruby
# 修正前
reaction.channel_id = event.message.channel.id  # HTTP リクエスト発生
reaction.message_id = event.message.id           # 同上

# 修正後
reaction.channel_id = event.channel.id   # キャッシュから取得（HTTP なし）
reaction.message_id = event.message_id   # attr_reader から取得（HTTP なし）
```

### 3. `app/models/channel_array_maker.rb` — Rate Limit 発生時のリトライ処理を追加

`fetch_channel_info` の呼び出しを `fetch_channel` プライベートメソッドに切り出し、`JSON::ParserError`（Cloudflare 429 が原因）発生時に指数バックオフ（1秒 → 2秒 → 4秒）で最大3回リトライする処理を追加。3回リトライしても失敗する場合はエラーを伝播させる。

```ruby
def self.fetch_channel(channel_id, attempt: 0)
  JSON.parse(DiscordApiClient.new.fetch_channel_info(channel_id))
rescue JSON::ParserError
  raise if attempt >= 3
  sleep(2**attempt)
  fetch_channel(channel_id, attempt: attempt + 1)
end
```

---

## テスト強化

`spec/models/channel_array_maker_spec.rb` に Rate Limit 発生時の挙動を検証する2ケースを追加。

- `JSON::ParserError` が一度発生してもリトライして正常に結果を返すこと
- 3回リトライしても失敗し続ける場合は `JSON::ParserError` が伝播すること

---

## 特記事項

- `reactions` テーブルへのデータ蓄積（Bot によるリアクション記録）は正常に動作しており、今回の問題は `ranks:create` バッチのみに影響していた
- discordrb の Rate Limit ハンドラは Discord 公式 API からの JSON 形式 429 を想定しており、Cloudflare 経由の HTML 形式 429 を正しくハンドリングできないバグがある。今回はアプリ側でこれを回避する
- Bot プロセスの WebSocket が頻繁に切断・再接続（Resumed）しているが、これは discordrb の既知の挙動であり今回の問題とは無関係

---

## テスト実行結果

```
68 examples, 0 failures
```